### PR TITLE
meson: Work around libmpc ignoring MSYS UCRT compilers

### DIFF
--- a/win32/meson.build
+++ b/win32/meson.build
@@ -7,9 +7,15 @@ win32Srcs = [
 ]
 win32Inc = include_directories('.')
 
+win32Args = []
+if isWindows and c.get_define('_MSC_VER') == ''
+	win32Args += ['-DUNIXEM_FORCE_ANY_COMPILER']
+endif
+
 win32Lib = static_library(
 	'win32',
 	win32Srcs,
+	c_args: win32Args,
 	include_directories: includes,
 	gnu_symbol_visibility: 'inlineshidden',
 	install: true


### PR DESCRIPTION
👋 

This is a small fix for libmpc originally not knowing that MSYS is a thing.