### PR TITLE
Fix: warnings

### DIFF
--- a/common/tags.c
+++ b/common/tags.c
@@ -629,13 +629,13 @@ IsUnicode ( const char* src, size_t len )
     if ( len & 1 )                                              // odd number of bytes?
         return 0;
 
-	if ( src [0] != (char)0xFF  ||  src [1] != (char)0xFE )     // Microsoft Unicode preample (also useful to detect endianess, but currently only little endian is supported)
+    if ( src [0] != (char)0xFF  ||  src [1] != (char)0xFE )     // Microsoft Unicode preample (also useful to detect endianess, but currently only little endian is supported)
         return 0;
 
     for ( len >>= 1; len > 0; len--, src += 2 ) {               // Check for invalid codes (FFFE, FFFF, DC00...DFFF without a prepend D800...DBFF, D800...DBFF without a n appended DC00...DFFF)
         if ( ( src [1] & 0xFC ) == 0xDC )
             return 0;
-		if ( src [1] == (char)0xFF  &&  ( src [0] & 0xFE ) == 0xFE )
+        if ( src [1] == (char)0xFF  &&  ( src [0] & 0xFE ) == 0xFE )
             return 0;
         if ( ( src [1] & 0xFC ) == 0xD8 ) {
             if ( len < 2  ||  ( src [3] & 0xFC ) != 0xDC )
@@ -737,7 +737,7 @@ addtag ( const char*           key,             // the item key
 
     p = malloc ( keylen );
     memcpy ( p, key, keylen );
-	T [TagCount] . key    = (char*) p;
+    T [TagCount] . key    = (char*) p;
     T [TagCount] . keylen = keylen;
 
     switch ( converttoutf8 ) {
@@ -854,14 +854,14 @@ FinalizeTags ( FILE* fp, unsigned int Version, unsigned int flags )
     if ( TagCount == 0 )
         return 0;
 
-	if (flags & TAG_NO_PREAMBLE) {
-		estimatedbytes -= 8;
-		writtenbytes += 8;
-	}
-	if (flags & TAG_NO_FOOTER)
-		estimatedbytes = 0;
-	if (flags & TAG_NO_HEADER)
-		writtenbytes = 0;
+    if (flags & TAG_NO_PREAMBLE) {
+        estimatedbytes -= 8;
+        writtenbytes += 8;
+    }
+    if (flags & TAG_NO_FOOTER)
+        estimatedbytes = 0;
+    if (flags & TAG_NO_HEADER)
+        writtenbytes = 0;
 
     qsort ( T, TagCount, sizeof (*T), cmpfn2 );
 
@@ -885,12 +885,12 @@ FinalizeTags ( FILE* fp, unsigned int Version, unsigned int flags )
     H [19] = TagCount >> 24;
 
     H [23] = 0x80 | 0x20;
-	if (!(flags & TAG_NO_HEADER)) {
-		if (flags & TAG_NO_PREAMBLE)
-			writtenbytes += fwrite ( H + 8, 1, 24, fp );
-		else
-    		writtenbytes += fwrite ( H, 1, 32, fp );
-	}
+    if (!(flags & TAG_NO_HEADER)) {
+        if (flags & TAG_NO_PREAMBLE)
+            writtenbytes += fwrite ( H + 8, 1, 24, fp );
+        else
+            writtenbytes += fwrite ( H, 1, 32, fp );
+    }
 
     for ( i = 0; i < TagCount; i++ ) {
         dw [0] = T [i] . valuelen >>  0;
@@ -909,15 +909,15 @@ FinalizeTags ( FILE* fp, unsigned int Version, unsigned int flags )
     }
 
     H [23] = 0x80;
-	if (!(flags & TAG_NO_FOOTER)) {
-		if (flags & TAG_NO_PREAMBLE)
-			writtenbytes += fwrite ( H + 8, 1, 24, fp );
-		else
-			writtenbytes += fwrite ( H, 1, 32, fp );
-	}
+    if (!(flags & TAG_NO_FOOTER)) {
+        if (flags & TAG_NO_PREAMBLE)
+            writtenbytes += fwrite ( H + 8, 1, 24, fp );
+        else
+            writtenbytes += fwrite ( H, 1, 32, fp );
+    }
 
     if ( estimatedbytes != writtenbytes )
-		fprintf (stderr, "\nError writing APE tag.\n" );
+        fprintf (stderr, "\nError writing APE tag.\n" );
 
     TagCount = 0;
     return 0;
@@ -966,7 +966,7 @@ CopyTags_ID3 ( FILE* fp )
     if ( -1 == fseek ( fp, -128L, SEEK_END ) )
         return -1;
 
-	if ( 128 != fread(tmp, 1, 128, fp) )
+    if ( 128 != fread(tmp, 1, 128, fp) )
         return -1;
 
     if ( 0 != memcmp ( tmp, "TAG", 3 ) ) {
@@ -976,11 +976,11 @@ CopyTags_ID3 ( FILE* fp )
     if ( !tmp[3]  &&  !tmp[33]  &&  !tmp[63]  &&  !tmp[93]  &&  !tmp[97] )
         return -1;
 
-	memcpy_crop  ( "Title"  , (char*)tmp +  3, 30, 0 );
-	memcpy_crop  ( "Artist" , (char*)tmp + 33, 30, 0 );
-	memcpy_crop  ( "Album"  , (char*)tmp + 63, 30, 0 );
-	memcpy_crop  ( "Year"   , (char*)tmp + 93,  4, 0 );
-	memcpy_crop  ( "Comment", (char*)tmp + 97, 30, 0 );
+    memcpy_crop  ( "Title"  , (char*)tmp +  3, 30, 0 );
+    memcpy_crop  ( "Artist" , (char*)tmp + 33, 30, 0 );
+    memcpy_crop  ( "Album"  , (char*)tmp + 63, 30, 0 );
+    memcpy_crop  ( "Year"   , (char*)tmp + 93,  4, 0 );
+    memcpy_crop  ( "Comment", (char*)tmp + 97, 30, 0 );
 
     if ( tmp[127] < sizeof(GenreList)/sizeof(*GenreList) )
         if ( ! TagKeyExists ( "Genre", 0 ) )
@@ -988,8 +988,8 @@ CopyTags_ID3 ( FILE* fp )
 
     if ( tmp[125] == 0  &&  tmp[126] != 0 )
         if ( ! TagKeyExists ( "Track", 0 ) ) {
-		sprintf ( (char*)tmp, "%u",  tmp[126] );
-		addtag ("Track", 0, (char*)tmp, strlen ((char*)tmp), 0, 0 );
+            sprintf ( (char*)tmp, "%u",  tmp[126] );
+            addtag ("Track", 0, (char*)tmp, strlen ((char*)tmp), 0, 0 );
         }
 
     return 0;
@@ -1021,7 +1021,7 @@ CopyTags_APE ( FILE* fp )
 
     if ( -1 == fseek ( fp, -(long)sizeof T, SEEK_END ) )
         return -1;
-	if ( sizeof(T) != fread  (&T, 1, sizeof T, fp) )
+    if ( sizeof(T) != fread  (&T, 1, sizeof T, fp) )
         return -1;
     if ( memcmp ( T.ID, "APETAGEX", sizeof(T.ID) ) != 0 )
         return -1;
@@ -1041,10 +1041,11 @@ CopyTags_APE ( FILE* fp )
     for ( p = buff; TagCount--; ) {
         len   = Read_LE_Uint32 ( p );        p += 4;
         flags = Read_LE_Uint32 ( p );        p += 4;
-		strcpy ( (char*)key, (char*)p );                   p += strlen ((char*)key) + 1;
-		if ( ! TagKeyExists ( (char*)key, 0 ) )
-			addtag ( (char*)key, 0, (char*)p, len > 0  &&  p [len-1] == '\0'  ?  len-1  :  len, version >= 2000  ?  0  :  5, flags );
-                                             p += len;
+        strcpy ( (char*)key, (char*)p );
+        p += strlen ((char*)key) + 1;
+        if ( ! TagKeyExists ( (char*)key, 0 ) )
+            addtag ( (char*)key, 0, (char*)p, len > 0  &&  p [len-1] == '\0'  ?  len-1  :  len, version >= 2000  ?  0  :  5, flags );
+        p += len;
     }
 
     return 0;
@@ -1084,6 +1085,7 @@ CopyTags_APE ( FILE* fp )
 
 */
 
+#if 0
 static const char* const  parser_strings [] = {
     "/A_Tx",
     "/A/Tx",
@@ -1098,6 +1100,7 @@ static const char* const  parser_strings [] = {
     "/A/C N_0x",
     "/A/C_0x",
 };
+#endif
 
 /*
  *    dst[0] = Artist

--- a/libmpcpsy/ans.c
+++ b/libmpcpsy/ans.c
@@ -270,8 +270,6 @@ FindOptimalANS ( const int             MaxBand,
             }
         }
     }
-
-    return;
 }
 
 
@@ -293,8 +291,6 @@ NS_Analyse ( PsyModel* m,
 	memset ( m->FIR_R,      0, sizeof m->FIR_R      );         // reset FIR
 	memset ( m->NS_Order_R, 0, sizeof m->NS_Order_R );         // reset Flags
 	FindOptimalANS ( MaxBand, MSflag, ANSspec_R, ANSspec_S, m->NS_Order_R, m->SNR_comp_R, m->FIR_R, smr.R, smr.S, m->SCF_Index_R, Transient );
-
-    return;
 }
 
 /* end of ans.c */

--- a/libmpcpsy/libmpcpsy.h
+++ b/libmpcpsy/libmpcpsy.h
@@ -85,8 +85,7 @@ typedef struct {
 	float KBD2; // = -1.
 
 	// FIXME : remove this :
-	int * SCF_Index_L;
-	int * SCF_Index_R;              // Scalefactor-index for Bitstream
+	int (* SCF_Index_L)[3];
+	int (* SCF_Index_R)[3];              // Scalefactor-index for Bitstream
 
 } PsyModel;
-

--- a/mpcchap/iniparser.c
+++ b/mpcchap/iniparser.c
@@ -553,14 +553,12 @@ static line_status iniparser_line(
         /* Section name */
         sscanf(line, "[%[^]]", section);
         strcpy(section, strstrip(section));
-        strcpy(section, section);
         sta = LINE_SECTION ;
     } else if (sscanf (line, "%[^=] = \"%[^\"]\"", key, value) == 2
            ||  sscanf (line, "%[^=] = '%[^\']'",   key, value) == 2
            ||  sscanf (line, "%[^=] = %[^;#]",     key, value) == 2) {
         /* Usual key=value, with or without comments */
         strcpy(key, strstrip(key));
-        strcpy(key, key);
         strcpy(value, strstrip(value));
         /*
          * sscanf cannot handle '' or "" as empty values
@@ -579,7 +577,6 @@ static line_status iniparser_line(
          * key=#
          */
         strcpy(key, strstrip(key));
-        strcpy(key, key);
         value[0]=0 ;
         sta = LINE_VALUE ;
     } else {
@@ -610,7 +607,7 @@ dictionary * iniparser_load(const char * ininame)
     char line    [ASCIILINESZ+1] ;
     char section [ASCIILINESZ+1] ;
     char key     [ASCIILINESZ+1] ;
-    char tmp     [ASCIILINESZ+1] ;
+    char tmp     [(ASCIILINESZ+1)*2] ;
     char val     [ASCIILINESZ+1] ;
 
     int  last=0 ;
@@ -674,7 +671,7 @@ dictionary * iniparser_load(const char * ininame)
             break ;
 
             case LINE_VALUE:
-            sprintf(tmp, "%s:%s", section, key);
+            snprintf(tmp, sizeof(tmp), "%s:%s", section, key);
             errs = dictionary_set(dict, tmp, val) ;
             break ;
 

--- a/mpcchap/mpcchap.c
+++ b/mpcchap/mpcchap.c
@@ -189,7 +189,7 @@ mpc_status add_chaps_cue(char * mpc_file, char * chap_file, mpc_demux * demux, m
 
 	nchap = cd_get_ntrack(cd);
 	for (i = 1; i <= nchap; i++) {
-		char track_buf[16], block_header[12] = "CT", sample_offset[10];
+		char track_buf[22], block_header[12] = "CT", sample_offset[10];
 		int j, nitem = 0, tag_len = 0, key_len, item_len, offset_size;
 		Track * track;
 		Cdtext *cdtext;
@@ -207,7 +207,7 @@ mpc_status add_chaps_cue(char * mpc_file, char * chap_file, mpc_demux * demux, m
 
 		Init_Tags();
 
-		sprintf(track_buf, "%i/%i", i, nchap);
+		snprintf(track_buf, sizeof(track_buf), "%i/%i", i, nchap);
 		key_len = 5;
 		item_len = strlen(track_buf);
 		addtag("Track", key_len, track_buf, item_len, 0, 0);

--- a/mpcenc/mpcenc.c
+++ b/mpcenc/mpcenc.c
@@ -667,7 +667,6 @@ SCF_Extraktion ( PsyModel*m, mpc_encoder_t* e, const int MaxBand, SubbandFloatTy
                 }
             }
     }
-    return;
 }
 
 
@@ -706,7 +705,6 @@ Quantisierung ( PsyModel * m,
             }
         }
     }
-    return;
 }
 
 
@@ -799,7 +797,6 @@ Allocate ( const int MaxBand, int* res, float* x, int* scf, const float* comp, c
         }
 
     }
-    return;
 }
 
 
@@ -1537,8 +1534,8 @@ mainloop ( int argc, char** argv )
 
     // initialize tables which must be initialized once and only once
 
-	m.SCF_Index_L = (int*) e.SCF_Index_L;
-	m.SCF_Index_R = (int*) e.SCF_Index_R;
+	m.SCF_Index_L = e.SCF_Index_L;
+	m.SCF_Index_R = e.SCF_Index_R;
 
 	Init_Psychoakustik (&m);
 	Init_FPU ();

--- a/mpcenc/mpcenc.h
+++ b/mpcenc/mpcenc.h
@@ -241,8 +241,8 @@ extern float __invSCF [128 + 6];        // tabulated scalefactors (inverted)
 
 float  ISNR_Schaetzer                  ( const float* samples, const float comp, const int res);
 float  ISNR_Schaetzer_Trans            ( const float* samples, const float comp, const int res);
-void   QuantizeSubband                 ( unsigned int* qu_output, const float* input, const int res, float* errors, const int maxNsOrder );
-void   QuantizeSubbandWithNoiseShaping ( unsigned int* qu_output, const float* input, const int res, float* errors, const float* FIR );
+void   QuantizeSubband                 ( mpc_int16_t* qu_output, const float* input, const int res, float* errors, const int maxNsOrder );
+void   QuantizeSubbandWithNoiseShaping ( mpc_int16_t* qu_output, const float* input, const int res, float* errors, const float* FIR );
 
 void   NoiseInjectionComp ( void );
 


### PR DESCRIPTION
As part of sorting libAudio CI out, we noticed a large number of warnings coming from libmpc and its dependencies. This PR addresses the warnings coming out of libmpc.